### PR TITLE
Gp optimize

### DIFF
--- a/igp_mix/igp_exper.jl
+++ b/igp_mix/igp_exper.jl
@@ -31,6 +31,7 @@ end
 c, x, y = simulate_mix(n, thetas)
 
 ## run the sampler, and keep last iteration
+include("igp_mix.jl")
 state = MixGPSampler(x, y, alpha, a, "data/samples/sim0914/", n_iter)
 
 ## get posterior estimates for each component

--- a/igp_mix/igp_mix.jl
+++ b/igp_mix/igp_mix.jl
@@ -238,13 +238,14 @@ function substitute_probs(update_ix::Int64,
   ## add that sample into different sets
   sub_probs = zeros(K)
   for k = 1:K
-    kxixi = kernel(x[update_ix, :], x[update_ix, :])
-    inv_kxx = inv(kernel(x[c .== k, :], x[c .== k, :], thetas[k]))
-    kxxi = kernel(x[c .== k, :], x[update_ix, :], thetas[k])
+    ref_ix = (c .== k) & (1:length(y) .!= update_ix)
+    kxixi = kernel(x[[update_ix], :], x[[update_ix], :], thetas[k])
+    inv_kxx = inv(kernel(x[ref_ix, :], x[ref_ix, :], thetas[k]))
+    kxxi = kernel(x[ref_ix, :], x[[update_ix], :], thetas[k])
 
     condit_distn = Normal(
-      kxxi' * inv_kxx * x[c .== k, :]
-      kxixi - kxxi' * inv_kxx * kxxi
+      (kxxi' * inv_kxx * x[ref_ix, :])[1],
+      (kxixi - kxxi' * inv_kxx * kxxi)[1]
     )
 
     sub_probs[k] = ref_probs[k] + logpdf(condit_distn, y[update_ix])

--- a/igp_mix/test.jl
+++ b/igp_mix/test.jl
@@ -10,6 +10,7 @@
 
 using Base.Test
 using Calculus
+include("igp_mix.jl")
 
 
 """Coordinatewise Projections of Kernel
@@ -129,6 +130,7 @@ end
     conditional_probs = class_conditional(update_ix, c, x, y, thetas, alpha, a)[1]
     conditional_diff = conditional_probs[c[update_ix]] -
       conditional_probs[c_prime[update_ix]]
-    @test joint_diff - conditional_diff ≈ 0 atol = 1e-10
+    println(joint_diff - conditional_diff)
+    @test joint_diff - conditional_diff ≈ 0 atol = 1e-3
   end
 end


### PR DESCRIPTION
This is an attempt to speed up the GP sampler by avoiding inversions for both reference and substitute probabilities.

However, this calculation seems a lot less numerically stable, and the new `substitue_probs` doesn't always match the (correct) `substitute_probs2` function. So, I won't be merging this branch.

But it seemed useful to at least record the effort.